### PR TITLE
Use phoenix mime type handling to check for turbo requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ in `lib/[my_app]_web.ex`
    end
  end
 ```
+
+Configure new mime type
+in `config/config.exs`
+```diff
++  config :mime, :types, %{
++    "text/vnd.turbo-stream.html" => ["turbo-html"]
++  }
+```
+
+And recompile the mime plug after that
+
+```
+  mix deps.clean mime --build
+  mix deps.get
+```
 in `lib/[my_app]_web/endpoint.ex`
 ```diff
  defmodule MyAppWeb.Endpoint do
@@ -50,7 +65,7 @@ in `lib/[my_app]_web/channels/user_socket.ex`
 in `lib/[my_app]_web/router.ex`
 ```diff
    pipeline :browser do
-     plug :accepts, ["html"]
++    plug :accepts, ["html", "turbo-html"]
      plug :fetch_session
      plug :fetch_flash
      plug :protect_from_forgery

--- a/lib/phoenix_turbo/controller_helper.ex
+++ b/lib/phoenix_turbo/controller_helper.ex
@@ -7,12 +7,17 @@ defmodule PhoenixTurbo.ControllerHelper do
   @doc """
   Return true if it's a "turbo-stream" request.
   E.g. Clicking link or submitting form inside the <turbo-frame> tag.
+  Configure new mime type with
+  config :mime, :types, %{
+    "text/vnd.turbo-stream.html" => ["turbo-html"]
+  }
+  And then
+  mix deps.clean mime --build
+  mix deps.get
   """
   @spec turbo_stream_request?(Plug.Conn.t()) :: boolean()
   def turbo_stream_request?(conn) do
-    [accept_types] = get_req_header(conn, "accept")
-    # `accept_types` is "text/vnd.turbo-stream.html, text/html, application/xhtml+xml"
-    String.starts_with?(accept_types, @turbo_stream_content_type)
+    get_format(conn) == "turbo-html"
   end
 
   @doc """


### PR DESCRIPTION
Hi, maybe we could use the native phoenix mime type handling to check for turbo requests instead of manually checking for the `accept` header values.

Not fully tested yet